### PR TITLE
Add the `disabled_by_default` option to `ble_client`

### DIFF
--- a/esphome/components/ble_client/__init__.py
+++ b/esphome/components/ble_client/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import esp32_ble_tracker, esp32_ble_client
 from esphome.const import (
     CONF_CHARACTERISTIC_UUID,
+    CONF_DISABLED_BY_DEFAULT,
     CONF_ID,
     CONF_MAC_ADDRESS,
     CONF_NAME,
@@ -66,6 +67,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(BLEClient),
             cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_NAME): cv.string,
+            cv.Optional(CONF_DISABLED_BY_DEFAULT): cv.boolean,
             cv.Optional(CONF_ON_CONNECT): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -239,6 +241,10 @@ async def to_code(config):
     await cg.register_component(var, config)
     await esp32_ble_tracker.register_client(var, config)
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
+
+    if CONF_DISABLED_BY_DEFAULT in config:
+        cg.add(var.set_disabled_by_default(config[CONF_DISABLED_BY_DEFAULT]))
+
     for conf in config.get(CONF_ON_CONNECT, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -14,7 +14,10 @@ static const char *const TAG = "ble_client";
 
 void BLEClient::setup() {
   BLEClientBase::setup();
-  this->enabled = true;
+
+  if (!this->disabled_by_default_) {
+    this->enabled = true;
+  }
 }
 
 void BLEClient::loop() {

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -50,6 +50,7 @@ class BLEClient : public BLEClientBase {
   void setup() override;
   void dump_config() override;
   void loop() override;
+  void set_disabled_by_default(bool disabled_by_default) { disabled_by_default_ = disabled_by_default; }
 
   bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
@@ -70,6 +71,8 @@ class BLEClient : public BLEClientBase {
   void set_state(espbt::ClientState state) override;
 
  protected:
+  bool disabled_by_default_ = false;
+
   bool all_nodes_established_();
 
   std::vector<BLEClientNode *> nodes_;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
